### PR TITLE
fix: mailbox send crash

### DIFF
--- a/common/src/main/java/com/starfish_studios/yaf/YetAnotherFurnitureClient.java
+++ b/common/src/main/java/com/starfish_studios/yaf/YetAnotherFurnitureClient.java
@@ -69,13 +69,13 @@ public class YetAnotherFurnitureClient {
 
         NetworkManager.registerReceiver(NetworkManager.Side.S2C, MailboxBlockEntity.packetChannel2, ((buf, context) -> {
             var pos = buf.readBlockPos();
-            var state = buf.readBoolean();
             var client = Minecraft.getInstance();
+            
             client.execute(() -> {
                 assert client.level != null;
                 var be = client.level.getBlockEntity(pos);
                 if (be instanceof MailboxBlockEntity mailbox) {
-                    mailbox.failedToSend = state;
+                    mailbox.targetString = "";
                     mailbox.setChanged();
                 }
             });


### PR DESCRIPTION
This PR fixes the mailbox send crash. Uses the networking logic from main. Closes #7.